### PR TITLE
goreleaser: build tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+# https://goreleaser.com/ci/actions/
+name: Build test
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  build_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          # skips announce and artifact uploads
+          # https://goreleaser.com/cmd/goreleaser_release/
+          args: release --rm-dist --skip-announce --skip-publish

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,21 @@
+# ref. https://goreleaser.com/customization/build/
+builds:
+  - main: ./main
+    binary: ava-sim
+    # TODO: remove this once we support 32-bit in avalanchego
+    ignore:
+      - goos: darwin
+        goarch: 386
+      - goos: linux
+        goarch: 386
+      - goos: windows
+        goarch: 386
+      - goos: freebsd
+        goarch: 386
+
+release:
+  # Repo in which the release will be created.
+  # Default is extracted from the origin remote URL or empty if its private hosted.
+  github:
+    owner: ava-labs
+    name: ava-sim


### PR DESCRIPTION
We need ava-sim binaries to run e2e tests in other projects.

Tested in my fork.

<img width="816" alt="Screen Shot 2021-12-07 at 8 49 47 PM" src="https://user-images.githubusercontent.com/6799218/145150065-c094e4ef-c464-4d62-bfca-151d7510d96d.png">

<img width="843" alt="Screen Shot 2021-12-07 at 8 49 38 PM" src="https://user-images.githubusercontent.com/6799218/145150054-48bc72ac-2a66-4127-9619-bc605e5d7ca5.png">

