### PR TITLE
README: timestampvm.getBlock parameters shoudn't send an empty ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,7 @@ custom VM [here](https://docs.avax.network/build/tutorials/platform/create-custo
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "timestampvm.getBlock",
-    "params":{
-        "id":""
-    },
+    "params":{},
     "id": 1
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/28TtJ7sdYvdgfj1CcXo5o3yXFMhKLrv4FQC9WhgSHgY6YNYRs2
 ```


### PR DESCRIPTION
While doing https://github.com/ava-labs/ava-sim#example-timestampvm I got the error:
```
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32000,
    "message": "couldn't unmarshal an argument. Ensure arguments are valid and properly formatted. See documentation for example calls",
    "data": null
  },
  "id": 1
}
```

The `id` is an empty string that doesn't get interpreted as `nil` [here](https://github.com/ava-labs/timestampvm/blob/7d60b61b0b1a33e5ec95941f84e138450f89d41a/timestampvm/service.go#L77). Which ultimately tries to [unmarshal it](https://github.com/ava-labs/avalanchego/blob/cc8dc3006d91e76c7b2555aa27737304751dbeea/ids/id.go#L59) with an error. This error bubbles to the [generic arg parsing](https://github.com/ava-labs/avalanchego/blob/cc8dc3006d91e76c7b2555aa27737304751dbeea/utils/json/codec.go#L62) with that [exact error message](https://github.com/ava-labs/avalanchego/blob/cc8dc3006d91e76c7b2555aa27737304751dbeea/utils/json/codec.go#L25).

Post-edit: [Further evidence](https://docs.avax.network/build/tutorials/platform/create-custom-blockchain#verify-genesis-block) for this change.